### PR TITLE
ログアウトのエラーを解消

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,5 @@
 class SessionsController < ApplicationController
+
   def new
   end
 
@@ -8,13 +9,13 @@ class SessionsController < ApplicationController
       log_in user
       redirect_to user
     else
-      flash.now[:danger] = 'invalid email/password combination'
+      flash.now[:danger] = 'Invalid email/password combination'
       render 'new'
     end
   end
 
   def destroy
-    log_out
+    reset_session
     redirect_to root_url
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   root to: 'home#top'
-  get 'signup', to: 'users#new'
-  get 'login', to: 'sessions#new'
-  post 'login', to: 'sessions#create'
-  delete 'logout', to: 'sessions#destroy'
+  get '/signup', to: 'users#new'
+  get '/login', to: 'sessions#new'
+  post '/login', to: 'sessions#create'
+  delete '/logout', to: 'sessions#destroy'
   resources :users
 end


### PR DESCRIPTION
ログアウト時のエラーを解消しました。
エラーメッセージはsessions.controller.rbに対するもので、内容は「log_outメソッドは宣言されていないので使えません」的な感じでした。しかしsessions_helper.rbでしっかり宣言していたので、結局なぜこのエラーが起きているのかよくわかりませんでした。

なので、対症療法として、自分で定義したメソッドを用いる代わりに、元から定義されているreset_sessionメソッドを用いることにしました。