### PR TITLE
投稿機能, 投稿一覧機能, 投稿詳細機能を追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,8 +1,10 @@
 class PostsController < ApplicationController
   def index
+    @posts = Post.all
   end
 
   def show
+    @post = Post.find(params[:id])
   end
 
   def new
@@ -10,5 +12,17 @@ class PostsController < ApplicationController
   end
 
   def edit
+  end
+
+  def create
+    post = Post.new(post_params)
+    post.save!
+    redirect_to posts_url, notice: "投稿しました"
+  end
+
+  private
+
+  def post_params
+    params.require(:post).permit(:content)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,9 +10,12 @@
   <body>
     <%= render 'layouts/header' %>
     <div class="container">
-      <% flash.each do |message_type, message| %>
-        <div class="alert alert-<%= message_type %>"><%= message %></div>
+      <% if flash.notice.present? %>
+        <div class="alert alert-success"><%= flash.notice %></div>
       <% end %>
+      <!-- <% flash.each do |message_type, message| %> -->
+        <!-- <div class="alert alert-<%= message_type %>"><%= message %></div> -->
+      <!-- <% end %> -->
       <%= yield %>
       <!-- <%= debug(params) if Rails.env.development? %> -->
     </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,2 +1,22 @@
-<h1> タスク一覧 </h1>
+<h1> 投稿一覧 </h1>
+
 <%= link_to "新規登録", new_post_path, class: "btn btn-primary" %>
+
+<div class="mb-3">
+  <table class="table table-hover">
+    <thead class="thead-default">
+      <tr>
+        <th><%= Post.human_attribute_name(:content) %></th>
+        <th><%= Post.human_attribute_name(:created_at) %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @posts.each do |post| %>
+        <tr>
+          <td><%= link_to post.content, post %></td>
+          <td><%= post.created_at %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -4,10 +4,10 @@
   <%= link_to "一覧", posts_path, class: "nav-link" %>
 </div>
 
-<%= form_with model: @task, local: true do |f| %>
+<%= form_with model: @post, local: true do |f| %>
   <div class="form-group">
     <%= f.label :content %>
-    <%= f.text_field :content, class: "form-control", id: "task_name" %>
+    <%= f.text_field :content, class: "form-control", id: "post_name" %>
   </div>
-  <%= f.submit nil, class: "btn btn-primary" %>
+  <%= f.submit "登録する", class: "btn btn-primary" %>
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,2 +1,26 @@
-<h1>Posts#show</h1>
-<p>Find me in app/views/posts/show.html.erb</p>
+<h1> 投稿詳細 </h1>
+
+<div class="nav justify-content-end">
+  <%= link_to "一覧", posts_path, class: "nav-link" %>
+</div>
+
+<table class="table table-hover">
+  <tbody>
+    <tr>
+      <th><%= Post.human_attribute_name(:id) %></th>
+      <td><%= @post.id %></td>
+    </tr>
+    <tr>
+      <th><%= Post.human_attribute_name(:content) %></th>
+      <td><%= simple_format(h(@post.content), {}, sanitize: false, wrapper_tag: "div") %></td>
+    </tr>
+    <tr>
+      <th><%= Post.human_attribute_name(:created_at) %></th>
+      <td><%= @post.created_at %></td>
+    </tr>
+    <tr>
+      <th><%= Post.human_attribute_name(:updated_at) %></th>
+      <td><%= @post.updated_at %></td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
「Ruby on Rails5 速修実践ガイド」を参考に、投稿機能, 投稿一覧表示機能, 投稿詳細機能を実装しました。
投稿一覧ページや投稿詳細ページに何を表示して何を表示しないのかは、追い追い修正を加える必要があると思います。