### PR TITLE
自分の投稿にだけ編集 / 削除ボタンが表示される

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,6 +8,7 @@ class PostsController < ApplicationController
   end
 
   def show
+    @user = Post.find_by(id: params[:id]).user
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,8 +9,8 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(params[:id])
-    @posts = current_user.posts.order(created_at: :desc)
+    @user = User.find_by(id: params[:id])
+    @posts = @user.posts.order(created_at: :desc)
   end
 
   def new

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -17,5 +17,7 @@
   </tbody>
 </table>
 
+<% if @user == current_user %>
 <%= link_to('編集', edit_post_path, class: 'btn btn-primary mr-3') %>
 <%= link_to('削除', @post, method: :delete, data: {confirm: 'この投稿を削除します。よろしいですか？'}, class: 'btn btn-danger') %>
+<% end %>

--- a/app/views/shared/_post_form.html.erb
+++ b/app/views/shared/_post_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: @post, local: true) do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <div class="field">
-    <%= f.text_area :content, placeholder: "Compose new micropost..." %>
+    <%= f.text_area :content, placeholder: 'どんなことに困っていますか？' %>
   </div>
   <%= f.submit 'Post', class: 'btn btn-primary' %>
 <% end %>


### PR DESCRIPTION
投稿詳細ページで、ログインユーザーの投稿にのみ編集 / 削除ボタンが表示されるようにしました。