### PR TITLE
コメント削除機能の追加

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -4,14 +4,14 @@ class LikesController < ApplicationController
   def create
     like = Like.new(user_id: current_user.id, post_id: params[:post_id])
     like.save
-    @user = User.find(current_user.id)
-    @post = Post.find(params[:post_id])
+    @user = User.find_by(id: current_user.id)
+    @post = Post.find_by(id: params[:post_id])
   end
 
   def destroy
     like = Like.find_by(post_id: params[:post_id], user_id: current_user)
     like.destroy
-    @user = User.find(current_user.id)
-    @post = Post.find(params[:post_id])
+    @user = User.find_by(id: current_user.id)
+    @post = Post.find_by(id: params[:post_id])
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
   include SessionsHelper
   before_action :set_post, only: [:show, :edit, :update, :destroy]
-  before_action :logged_in_user, only: [:create, :destroy]
+  before_action :logged_in_user, only: [:show, :index, :edit, :create, :destroy]
 
   def index
     @posts = Post.all.order(id: 'DESC').page(params[:page]).per(10)
@@ -31,13 +31,17 @@ class PostsController < ApplicationController
   end
 
   def update
-    @post.update!(post_params)
-    flash[:success] = '投稿を更新しました'
-    redirect_to posts_url
+    @post = Post.find_by(id: params[:id])
+    if @post.update(post_params)
+      flash[:success] = '投稿を更新しました'
+      redirect_to posts_url
+    else
+      render 'edit'
+    end
   end
 
   def destroy
-    Post.find(params[:id]).destroy
+    Post.find_by(id: params[:id]).destroy
     flash[:success] = '投稿を削除しました'
     redirect_to posts_url
   end

--- a/app/controllers/progresses_controller.rb
+++ b/app/controllers/progresses_controller.rb
@@ -7,8 +7,8 @@ class ProgressesController < ApplicationController
   end
 
   def create
-    @post = Post.find(params[:post_id])
-    @progress = @post.progresses.new(progress_params)
+    post = Post.find_by(id: params[:post_id])
+    @progress = post.progresses.new(progress_params)
     if @progress.save
       flash[:success] = '進捗を記録しました'
       redirect_to posts_url
@@ -18,18 +18,22 @@ class ProgressesController < ApplicationController
   end
 
   def show
-
+    @user = Post.find_by(id: params[:post_id]).user
+    @post = Post.find_by(id: params[:post_id])
   end
 
   def edit
   end
 
   def update
-
+    post = Post.find_by(id: params[:post_id])
+    @progress = Progress.find_by(id: params[:post_id])
   end
 
   def destroy
-
+    Progress.find_by(id: params[:id]).destroy
+    flash[:success] = '進捗を削除しました'
+    redirect_to posts_url
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   include SessionsHelper
-  before_action :logged_in_user, only:[:index, :edit, :update, :destroy]
+  before_action :logged_in_user, only:[:show, :index, :edit, :update, :destroy]
   before_action :correct_user, only:[:edit, :update]
   before_action :admin_user, only: :destroy
 
@@ -29,18 +29,21 @@ class UsersController < ApplicationController
   end
 
   def edit
-    @user = User.find(params[:id])
+    @user = User.find_by(id: params[:id])
   end
 
   def update
-    @user = User.find(params[:id])
-    @user.update!(user_params)
-    flash[:success] = 'プロフィールが変更されました'
-    redirect_to @user
+    @user = User.find_by(id: params[:id])
+    if @user.update(user_params)
+      flash[:success] = 'プロフィールが変更されました'
+      redirect_to @user
+    else
+      render 'edit'
+    end
   end
 
   def destroy
-    User.find(params[:id]).destroy
+    User.find_by(id: params[:id]).destroy
     flash[:success] = 'ユーザーは削除されました'
     redirect_to users_url
   end
@@ -52,7 +55,7 @@ class UsersController < ApplicationController
     end
 
     def correct_user
-      @user = User.find(params[:id])
+      @user = User.find_by(id: params[:id])
       redirect_to(root_url) unless current_user?(@user)
     end
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -22,6 +22,6 @@
 </div>
 
 <% if @user == current_user %>
-  <%= link_to('編集', edit_post_path, class: 'btn btn-primary mr-3') %>
-  <%= link_to('削除', @post, method: :delete, data: {confirm: 'この投稿を削除します。よろしいですか？'}, class: 'btn btn-danger') %>
+  <%= link_to '編集', edit_post_path, class: 'btn btn-primary mr-3' %>
+  <%= link_to '削除', @post, method: :delete, data: {confirm: 'この投稿を削除します。よろしいですか？'}, class: 'btn btn-danger' %>
 <% end %>

--- a/app/views/progresses/_progress.html.erb
+++ b/app/views/progresses/_progress.html.erb
@@ -1,4 +1,4 @@
 <%= link_to 'その後の進捗を記入する', new_post_progress_path(post_id: post.id) %>
 <% post.progresses.each do |progress| %>
-  <%= progress.content %>
+  <%= link_to progress.content, post_progress_path(post_id: post.id, id: progress.id) %>
 <% end %>

--- a/app/views/progresses/show.html.erb
+++ b/app/views/progresses/show.html.erb
@@ -1,0 +1,6 @@
+<h1>進捗詳細</h1>
+
+<% if @user == current_user %>
+  <%= link_to '編集', edit_post_progress_path, class: 'btn btn-primary mr-3' %>
+  <%= link_to '削除', post_progress_path, method: :delete, data: {confirm: 'この進捗を削除します。よろしいですか？'}, class: 'btn btn-danger' %>
+<% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,41 +12,41 @@
 
 ActiveRecord::Schema.define(version: 2020_07_19_095342) do
 
-  create_table 'likes', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.integer 'user_id', null: false
-    t.integer 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_likes_on_post_id'
-    t.index ['user_id', 'post_id'], name: 'index_likes_on_user_id_and_post_id', unique: true
-    t.index ['user_id'], name: 'index_likes_on_user_id'
+  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id", "post_id"], name: "index_likes_on_user_id_and_post_id", unique: true
+    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
-  create_table 'posts', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.text 'content'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.bigint 'user_id', null: false
-    t.index ['user_id'], name: 'index_posts_on_user_id'
+  create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "content"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
-  create_table 'progresses', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.text 'content'
-    t.bigint 'post_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['post_id'], name: 'index_progresses_on_post_id'
+  create_table "progresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "content"
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_progresses_on_post_id"
   end
 
-  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name'
-    t.string 'email'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.string 'password_digest'
-    t.boolean 'admin', default: false
-    t.index ['email'], name: 'index_users_on_email', unique: true
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "password_digest"
+    t.boolean "admin", default: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  add_foreign_key 'progresses', 'posts'
+  add_foreign_key "progresses", "posts"
 end


### PR DESCRIPTION
コメントの削除ボタンは既に実装していましたが、押下するとエラーが発生していました。
それを解消した次第です。
また、未ログイン時に投稿一覧を表示するとエラーになる事象、ユーザー編集で何も入力せずに更新ボタンを押すとフラッシュではなくエラー画面になる事象も合わせて解決しています。