### PR TITLE
アコーディオンパネルのレイアウトを改善

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -57,6 +57,10 @@ textarea {
   margin-bottom: 10px;
 }
 
+li {
+  list-style: none;
+}
+
 /* forms */
 
 input, textarea, select, .uneditable-input {
@@ -84,10 +88,6 @@ input {
 //     color: red;
 //   }
 // }
-
-li {
-  list-style: none;
-}
 
 /* ページネーション */
 
@@ -208,5 +208,26 @@ span.image {
   margin-top: 10px;
   input {
     border: 0;
+  }
+}
+
+/* アコーディオン */
+
+.accordion {
+  p {
+    display: block;
+    width: 200px;
+    height: 50px;
+    line-height: 50px;
+    text-align: center;
+    border:#666 1px groove;
+    cursor: pointer;
+  }
+
+  .accordion-elements {
+    background: #f2f2f2;
+    text-align: center;
+    border: #666 1px groove;
+    display: none;
   }
 }

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,45 +1,48 @@
 <%= form_with(model: @post, local: true) do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
+  <p>ステップ1</p>
   <div class="field">
     <%= f.text_area :content, class: 'form-control', id: 'post_content', placeholder: 'どんなことに困っていますか？' %>
   </div>
   <script>
     $(function(){
-      $("dd").hide();
+      $(".accordion-elements").hide();
 
-      $("#Accordion dt").on("click", function() {
+      $(".accordion p").on("click", function() {
         $(this).next().slideToggle();
       });
     });
   </script>
-  <dl id="Accordion">
-    <dt>ステップ2</dt>
-    <dd>
+  <div class="accordion">
+    <p>ステップ2</p>
+    <div class="accordion-elements">
       <div class="field">
         <%= f.label :困りごとのきっかけは何でしたか？ %>
-        <%= f.text_area :content, class: 'form-control' %>
+        <%= f.text_area :content, class: 'form-control', id: 'post_content' %>
       </div>
       <div class="field">
         <%= f.label :困りごとはどのような状況で発生しますか？ %>
-        <%= f.text_area :content, class: 'form-control' %>
+        <%= f.text_area :content, class: 'form-control', id: 'post_content' %>
       </div>
       <div class="field">
         <%= f.label :どうなればうれしいですか？ %>
-        <%= f.text_area :content, class: 'form-control' %>
+        <%= f.text_area :content, class: 'form-control', id: 'post_content' %>
       </div>
       <div class="field">
         <%= f.label :今どのように感じていますか？ %>
-        <%= f.text_area :content, class: 'form-control' %>
+        <%= f.text_area :content, class: 'form-control', id: 'post_content' %>
       </div>
-    </dd>
-    <dt>ステップ3</dt>
-    <dd>
+    </div>
+  </div>
+  <div class="accordion">
+    <p>ステップ3</p>
+    <div class="accordion-elements">
       <div class="field">
         <%= f.label :よくしていくために、これからどうしますか？ %>
         <%= f.text_area :content, class: 'form-control' %>
       </div>
-    </dd>
-  </dl>
+    </div>
+  </div>
 
   <%= f.submit yield(:button_text), class: 'btn btn-primary' %>
 <% end %>


### PR DESCRIPTION
アコーディオンパネルのレイアウトをCSSで整えました。
カーソルがパネルの上に乗ると、指のマークに変わるようになっています。