### PR TITLE
投稿一覧ページのレイアウト改善

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -75,10 +75,6 @@ li {
   display: flex;
 }
 
-.user_icon {
-  width: 50px;
-}
-
 /* テーブル */
 
 .table {
@@ -157,15 +153,6 @@ aside {
   }
 }
 
-.gravatar {
-  float: left;
-  margin-right: 10px;
-}
-
-.gravatar_edit {
-  margin-top: 15px;
-}
-
 /* ユーザー一覧 */
 
 .users {
@@ -187,27 +174,46 @@ aside {
     padding: 10px 0;
     border-top: 1px solid #e8e8e8;
   }
+
   .user {
     margin-top: 5em;
     padding-top: 0;
   }
-  .content {
-    display: block;
-    margin-left: 60px;
-    img {
-      display: block;
-      padding: 5px 0;
-    }
+
+  .user_icon {
+    width: 50px;
   }
+
+  // .content {
+  //   padding-bottom: 20px;
+  // }
+
   .timestamp {
     color: gray;
-    display: block;
+    display: inline-block;
     margin-left: 60px;
   }
-  .gravatar {
-    float: left;
-    margin-right: 10px;
-    margin-top: 5px;
+
+
+  .wakaru_button {
+    padding-left: 80px;
+    display: inline-block;
+  }
+
+  .like_button {
+    display: inline-block;
+  }
+
+  .teinei_button {
+    display: inline-block;
+  }
+
+  .ouen_button {
+    display: inline-block;
+  }
+
+  #progress_button {
+    width: 40%;
   }
 }
 
@@ -225,20 +231,27 @@ span.image {
   }
 }
 
+#search_form {
+  position: absolute;
+  top: 100px;
+  right: 100px;
+}
+
 /* アコーディオン */
 
 .accordion_wrapper {
   position: relative;
-  margin: 1.875em auto;
+  margin: 37.5px auto;
   width: 100%;
   border-top: none;
   outline: 0;
   cursor: pointer;
 
   .accordion_title {
+    position: relative;
     display: block;
-    padding: 0.625em 0.625em 0.625em 2em;
-    font-size: 1.25em;
+    padding: 12.5px 12.5px 12.5px 40px;
+    font-size: 20px;
     font-weight: normal;
     color: #fff;
     background: #1abc9c;
@@ -247,11 +260,11 @@ span.image {
 
   .accordion_content {
     display: none;
-    padding-left: 2.3125em;
+    padding: 20px 20px 0 20px;
   }
 
   .accordion_content_display {
-    padding-left: 2.3125em;
+    padding: 20px 20px 0 20px;
   }
 
   .accordion_title:after {

--- a/app/views/erais/_erai.html.erb
+++ b/app/views/erais/_erai.html.erb
@@ -1,24 +1,22 @@
-<% if logged_in? %>
-  <% erai = @progress.erais.find_by(user_id: current_user.id) %>
-  <div id="erai_button_<%= @progress.id %>">
-    <% if @progress.has_erai?(current_user) %>
-      <div class="erai">
-        <div class="row">
-          <div class="col-md-4 offset-md-4">
-            <%= button_to 'よかった済', post_progress_erai_path(progress_id: @progress.id, id: erai.id), class: 'btn btn-outline-info', id: 'unerai-button', method: :delete, remote: true %>
-            <%= @progress.erais.count %>
-          </div>
+<% erai = @progress.erais.find_by(user_id: current_user.id) %>
+<div id="erai_button_<%= @progress.id %>">
+  <% if @progress.has_erai?(current_user) %>
+    <div class="erai">
+      <div class="row">
+        <div class="col-md-4 offset-md-4">
+          <%= button_to 'よかった済', post_progress_erai_path(progress_id: @progress.id, id: erai.id), class: 'btn btn-outline-info', id: 'unerai-button', method: :delete, remote: true %>
+          <%= @progress.erais.count %>
         </div>
       </div>
-    <% else %>
-      <div class="unerai">
-        <div class="row">
-          <div class="col-md-4 offset-md-4">
-            <%= button_to 'よかった', post_progress_erais_path(progress_id: @progress.id), class: 'btn btn-outline-info', id: 'erai-button', method: :post, remote: true %>
-            <%= @progress.erais.count %>
-          </div>
+    </div>
+  <% else %>
+    <div class="unerai">
+      <div class="row">
+        <div class="col-md-4 offset-md-4">
+          <%= button_to 'よかった', post_progress_erais_path(progress_id: @progress.id), class: 'btn btn-outline-info', id: 'erai-button', method: :post, remote: true %>
+          <%= @progress.erais.count %>
         </div>
       </div>
-    <% end %>
-  </div>
-<% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/likes/_like.html.erb
+++ b/app/views/likes/_like.html.erb
@@ -1,24 +1,16 @@
-<% if logged_in? %>
-  <% like = post.likes.find_by(user_id: current_user.id) %>
+<% like = post.likes.find_by(user_id: current_user.id) %>
+<div class="like_button">
   <div id="like_button_<%= post.id %>">
     <% if post.has_like?(current_user) %>
       <div class="like">
-        <div class="row">
-          <div class="col-md-4 offset-md-4">
-            <%= button_to 'そうなんだ済', post_like_path(id: like.id, post_id: post.id), class: 'btn btn-outline-info', id: 'unlike-button', method: :delete, remote: true %>
-            <%= post.likes.count %>
-          </div>
-        </div>
+        <%= button_to 'そうなんだ', post_like_path(id: like.id, post_id: post.id), class: 'btn btn-success', id: 'unlike-button', method: :delete, remote: true %>
+        <%= post.likes.count %>
       </div>
     <% else %>
       <div class="unlike">
-        <div class="row">
-          <div class="col-md-4 offset-md-4">
-            <%= button_to 'そうなんだ', post_likes_path(post_id: post.id), class: 'btn btn-outline-info', id: 'like-button', method: :post, remote: true %>
-            <%= post.likes.count %>
-          </div>
-        </div>
+        <%= button_to 'そうなんだ', post_likes_path(post_id: post.id), class: 'btn btn-outline-success', id: 'like-button', method: :post, remote: true %>
+        <%= post.likes.count %>
       </div>
     <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -4,43 +4,41 @@
   <div class="form-inline">
     <span>
       <%= link_to user_path(visitor) do %>
-        <strong>
-          <%= visitor.name %>
-        </strong>
+        <b><%= visitor.name %></b>
       <% end %>
-      さんから
+      さんが
 
       <% case notification.action %>
       <% when 'like' then %>
-        この投稿にそうなんだをしました
+        この投稿にそうなんだと言っています
         <br>
         <%= link_to notification.post.content, notification.post %>
       <% when 'wakaru' then %>
-        この投稿にわかるをしました
+        この投稿にわかると言っています
         <br>
         <%= link_to notification.post.content, notification.post %>
       <% when 'teinei' then %>
-        この投稿にていねいをしました
+        この投稿にていねいと言っています
         <br>
         <%= link_to notification.post.content, notification.post %>
       <% when 'ouen' then %>
-        この投稿におうえんをしました
+        この投稿におうえんをしてくれています
         <br>
         <%= link_to notification.post.content, notification.post %>
       <% when 'erai' then %>
-        この進捗によかったをしました
+        この進捗によかったと言っています
         <br>
         <%= link_to notification.progress.content, notification.post %>
       <% when 'sounanda' then %>
-        この進捗にそうなんだをしました
+        この進捗にそうなんだと言っています
         <br>
         <%= link_to notification.progress.content, notification.post %>
       <% when 'teinei2' then %>
-        この進捗にていねいをしました
+        この進捗にていねいと言っています
         <br>
         <%= link_to notification.progress.content, notification.post %>
       <% when 'ouen2' then %>
-        この進捗におうえんをしました
+        この進捗におうえんをしてくれています
         <br>
         <%= link_to notification.progress.content, notification.post %>
       <% end %>

--- a/app/views/ouen2s/_ouen2.html.erb
+++ b/app/views/ouen2s/_ouen2.html.erb
@@ -1,24 +1,22 @@
-<% if logged_in? %>
-  <% ouen2 = @progress.ouen2s.find_by(user_id: current_user.id) %>
-  <div id="ouen2_button_<%= @progress.id %>">
-    <% if @progress.has_ouen2?(current_user) %>
-      <div class="ouen2">
-        <div class="row">
-          <div class="col-md-4 offset-md-4">
-            <%= button_to 'おうえん済', post_progress_ouen2_path(progress_id: @progress.id, id: ouen2.id), class: 'btn btn-outline-info', id: 'unouen2-button', method: :delete, remote: true %>
-            <%= @progress.ouen2s.count %>
-          </div>
+<% ouen2 = @progress.ouen2s.find_by(user_id: current_user.id) %>
+<div id="ouen2_button_<%= @progress.id %>">
+  <% if @progress.has_ouen2?(current_user) %>
+    <div class="ouen2">
+      <div class="row">
+        <div class="col-md-4 offset-md-4">
+          <%= button_to 'おうえん済', post_progress_ouen2_path(progress_id: @progress.id, id: ouen2.id), class: 'btn btn-outline-info', id: 'unouen2-button', method: :delete, remote: true %>
+          <%= @progress.ouen2s.count %>
         </div>
       </div>
-    <% else %>
-      <div class="unouen2">
-        <div class="row">
-          <div class="col-md-4 offset-md-4">
-            <%= button_to 'おうえん', post_progress_ouen2s_path(progress_id: @progress.id), class: 'btn btn-outline-info', id: 'ouen2-button', method: :post, remote: true %>
-            <%= @progress.ouen2s.count %>
-          </div>
+    </div>
+  <% else %>
+    <div class="unouen2">
+      <div class="row">
+        <div class="col-md-4 offset-md-4">
+          <%= button_to 'おうえん', post_progress_ouen2s_path(progress_id: @progress.id), class: 'btn btn-outline-info', id: 'ouen2-button', method: :post, remote: true %>
+          <%= @progress.ouen2s.count %>
         </div>
       </div>
-    <% end %>
-  </div>
-<% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/ouens/_ouen.html.erb
+++ b/app/views/ouens/_ouen.html.erb
@@ -1,24 +1,16 @@
-<% if logged_in? %>
-  <% ouen = post.ouens.find_by(user_id: current_user.id) %>
+<% ouen = post.ouens.find_by(user_id: current_user.id) %>
+<div class="ouen_button">
   <div id="ouen_button_<%= post.id %>">
     <% if post.has_ouen?(current_user) %>
       <div class="ouen">
-        <div class="row">
-          <div class="col-md-4 offset-md-4">
-            <%= button_to 'おうえん済', post_ouen_path(id: ouen.id, post_id: post.id), class: 'btn btn-outline-info', id: 'unouen-button', method: :delete, remote: true %>
-            <%= post.ouens.count %>
-          </div>
-        </div>
+        <%= button_to 'おうえん', post_ouen_path(id: ouen.id, post_id: post.id), class: 'btn btn-success', id: 'unouen-button', method: :delete, remote: true %>
+        <%= post.ouens.count %>
       </div>
     <% else %>
       <div class="unouen">
-        <div class="row">
-          <div class="col-md-4 offset-md-4">
-            <%= button_to 'おうえん', post_ouens_path(post_id: post.id), class: 'btn btn-outline-info', id: 'ouen-button', method: :post, remote: true %>
-            <%= post.ouens.count %>
-          </div>
-        </div>
+        <%= button_to 'おうえん', post_ouens_path(post_id: post.id), class: 'btn btn-outline-success', id: 'ouen-button', method: :post, remote: true %>
+        <%= post.ouens.count %>
       </div>
     <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -3,17 +3,23 @@
     <li id="post-<%= post.id %>">
       <%= image_tag post.user.image, class: 'user_icon' %>
       <span class="user"><%= link_to post.user.name, post.user %></span>
-      <%= link_to post.content.truncate(140), post %>
       <span class="timestamp">
         <%= time_ago_in_words(post.created_at) %>前
       </span>
+      <% if post.user == current_user %>
+        <%= button_to 'その後の進捗を記録する', new_post_progress_path(post_id: post.id), class: 'btn btn-outline-secondary', id: 'progress_button'%>
+      <% end %>
+      <div class="row">
+        <div class="col-md-10 offset-md-1">
+          <%= link_to post.content.truncate(140), post %>
+        </div>
+      </div>
+      <div class="buttons">
       <%= render 'wakarus/wakaru', post: post %>
       <%= render 'likes/like', post: post %>
       <%= render 'teineis/teinei', post: post %>
       <%= render 'ouens/ouen', post: post %>
-      <% if post.user == current_user %>
-        <%= link_to 'その後の進捗を記録する', new_post_progress_path(post_id: post.id) %>
-      <% end %>
+      </div>
       <%= render 'progresses/progress', post: post %>
     </li>
   <% end %>

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,4 +1,6 @@
-<%= search_form_for @q, url: posts_search_path do |f| %>
-  <%= f.search_field :content_cont, id: 'search_word', placeholder: '検索ワードを入力...', required: true %>
-  <%= f.submit ('検索'), class: 'btn btn-secondary' %>
-<% end %>
+<div id="search_form">
+  <%= search_form_for @q, url: posts_search_path do |f| %>
+    <%= f.search_field :content_cont, id: 'search_word', placeholder: '検索ワードを入力...', required: true %>
+    <%= f.submit ('検索'), class: 'btn btn-secondary' %>
+  <% end %>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,8 +1,8 @@
 <h1>みんなの困りごと</h1>
 
+<%= render 'search_form' %>
 <div class="row">
-  <div class="col-md-8 offset-md-2">
-    <%= render 'search_form' %>
+  <div class="col-md-7 offset-md-2">
     <% if @posts.any? %>
       <%= render 'post' %>
     <% end %>

--- a/app/views/progresses/_progress.html.erb
+++ b/app/views/progresses/_progress.html.erb
@@ -1,3 +1,6 @@
+<% if post.progresses.present? %>
+  <p>【進捗】</p>
+<% end %>
 <% post.progresses.order(id: 'DESC').each do |progress| %>
   <span class="timestamp">
     <%= time_ago_in_words(post.created_at) %>前

--- a/app/views/sounandas/_sounanda.html.erb
+++ b/app/views/sounandas/_sounanda.html.erb
@@ -1,24 +1,22 @@
-<% if logged_in? %>
-  <% sounanda = @progress.sounandas.find_by(user_id: current_user.id) %>
-  <div id="sounanda_button_<%= @progress.id %>">
-    <% if @progress.has_sounanda?(current_user) %>
-      <div class="sounanda">
-        <div class="row">
-          <div class="col-md-4 offset-md-4">
-            <%= button_to 'そうなんだ済', post_progress_sounanda_path(progress_id: @progress.id, id: sounanda.id), class: 'btn btn-outline-info', id: 'unsounanda-button', method: :delete, remote: true %>
-            <%= @progress.sounandas.count %>
-          </div>
+<% sounanda = @progress.sounandas.find_by(user_id: current_user.id) %>
+<div id="sounanda_button_<%= @progress.id %>">
+  <% if @progress.has_sounanda?(current_user) %>
+    <div class="sounanda">
+      <div class="row">
+        <div class="col-md-4 offset-md-4">
+          <%= button_to 'そうなんだ済', post_progress_sounanda_path(progress_id: @progress.id, id: sounanda.id), class: 'btn btn-outline-info', id: 'unsounanda-button', method: :delete, remote: true %>
+          <%= @progress.sounandas.count %>
         </div>
       </div>
-    <% else %>
-      <div class="unsounanda">
-        <div class="row">
-          <div class="col-md-4 offset-md-4">
-            <%= button_to 'そうなんだ', post_progress_sounandas_path(progress_id: @progress.id), class: 'btn btn-outline-info', id: 'sounanda-button', method: :post, remote: true %>
-            <%= @progress.sounandas.count %>
-          </div>
+    </div>
+  <% else %>
+    <div class="unsounanda">
+      <div class="row">
+        <div class="col-md-4 offset-md-4">
+          <%= button_to 'そうなんだ', post_progress_sounandas_path(progress_id: @progress.id), class: 'btn btn-outline-info', id: 'sounanda-button', method: :post, remote: true %>
+          <%= @progress.sounandas.count %>
         </div>
       </div>
-    <% end %>
-  </div>
-<% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/teinei2s/_teinei2.html.erb
+++ b/app/views/teinei2s/_teinei2.html.erb
@@ -1,24 +1,22 @@
-<% if logged_in? %>
-  <% teinei2 = @progress.teinei2s.find_by(user_id: current_user.id) %>
-  <div id="teinei2_button_<%= @progress.id %>">
-    <% if @progress.has_teinei2?(current_user) %>
-      <div class="teinei2">
-        <div class="row">
-          <div class="col-md-4 offset-md-4">
-            <%= button_to 'ていねい済', post_progress_teinei2_path(progress_id: @progress.id, id: teinei2.id), class: 'btn btn-outline-info', id: 'unteinei2-button', method: :delete, remote: true %>
-            <%= @progress.teinei2s.count %>
-          </div>
+<% teinei2 = @progress.teinei2s.find_by(user_id: current_user.id) %>
+<div id="teinei2_button_<%= @progress.id %>">
+  <% if @progress.has_teinei2?(current_user) %>
+    <div class="teinei2">
+      <div class="row">
+        <div class="col-md-4 offset-md-4">
+          <%= button_to 'ていねい済', post_progress_teinei2_path(progress_id: @progress.id, id: teinei2.id), class: 'btn btn-outline-info', id: 'unteinei2-button', method: :delete, remote: true %>
+          <%= @progress.teinei2s.count %>
         </div>
       </div>
-    <% else %>
-      <div class="unteinei2">
-        <div class="row">
-          <div class="col-md-4 offset-md-4">
-            <%= button_to 'ていねい', post_progress_teinei2s_path(progress_id: @progress.id), class: 'btn btn-outline-info', id: 'teinei2-button', method: :post, remote: true %>
-            <%= @progress.teinei2s.count %>
-          </div>
+    </div>
+  <% else %>
+    <div class="unteinei2">
+      <div class="row">
+        <div class="col-md-4 offset-md-4">
+          <%= button_to 'ていねい', post_progress_teinei2s_path(progress_id: @progress.id), class: 'btn btn-outline-info', id: 'teinei2-button', method: :post, remote: true %>
+          <%= @progress.teinei2s.count %>
         </div>
       </div>
-    <% end %>
-  </div>
-<% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/teineis/_teinei.html.erb
+++ b/app/views/teineis/_teinei.html.erb
@@ -1,24 +1,16 @@
-<% if logged_in? %>
-  <% teinei = post.teineis.find_by(user_id: current_user.id) %>
+<% teinei = post.teineis.find_by(user_id: current_user.id) %>
+<div class="teinei_button">
   <div id="teinei_button_<%= post.id %>">
     <% if post.has_teinei?(current_user) %>
       <div class="teinei">
-        <div class="row">
-          <div class="col-md-4 offset-md-4">
-            <%= button_to 'ていねい済', post_teinei_path(id: teinei.id, post_id: post.id), class: 'btn btn-outline-info', id: 'unteinei-button', method: :delete, remote: true %>
-            <%= post.teineis.count %>
-          </div>
-        </div>
+        <%= button_to 'ていねい', post_teinei_path(id: teinei.id, post_id: post.id), class: 'btn btn-success', id: 'unteinei-button', method: :delete, remote: true %>
+        <%= post.teineis.count %>
       </div>
     <% else %>
       <div class="unteinei">
-        <div class="row">
-          <div class="col-md-4 offset-md-4">
-            <%= button_to 'ていねい', post_teineis_path(post_id: post.id), class: 'btn btn-outline-info', id: 'teinei-button', method: :post, remote: true %>
-            <%= post.teineis.count %>
-          </div>
-        </div>
+        <%= button_to 'ていねい', post_teineis_path(post_id: post.id), class: 'btn btn-outline-success', id: 'teinei-button', method: :post, remote: true %>
+        <%= post.teineis.count %>
       </div>
     <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/wakarus/_wakaru.html.erb
+++ b/app/views/wakarus/_wakaru.html.erb
@@ -1,24 +1,16 @@
-<% if logged_in? %>
-  <% wakaru = post.wakarus.find_by(user_id: current_user.id) %>
+<% wakaru = post.wakarus.find_by(user_id: current_user.id) %>
+<div class="wakaru_button">
   <div id="wakaru_button_<%= post.id %>">
     <% if post.has_wakaru?(current_user) %>
       <div class="wakaru">
-        <div class="row">
-          <div class="col-md-4 offset-md-4">
-            <%= button_to 'わかる済', post_wakaru_path(id: wakaru.id, post_id: post.id), class: 'btn btn-outline-info', id: 'unwakaru-button', method: :delete, remote: true %>
-            <%= post.wakarus.count %>
-          </div>
-        </div>
+        <%= button_to 'わかる', post_wakaru_path(id: wakaru.id, post_id: post.id), class: 'btn btn-success', id: 'unwakaru-button', method: :delete, remote: true %>
+        <%= post.wakarus.count %>
       </div>
     <% else %>
       <div class="unwakaru">
-        <div class="row">
-          <div class="col-md-4 offset-md-4">
-            <%= button_to 'わかる', post_wakarus_path(post_id: post.id), class: 'btn btn-outline-info', id: 'wakaru-button', method: :post, remote: true %>
-            <%= post.wakarus.count %>
-          </div>
-        </div>
+        <%= button_to 'わかる', post_wakarus_path(post_id: post.id), class: 'btn btn-outline-success', id: 'wakaru-button', method: :post, remote: true %>
+        <%= post.wakarus.count %>
       </div>
     <% end %>
   </div>
-<% end %>
+</div>


### PR DESCRIPTION
投稿一覧ページのレイアウトを改善しました。
具体的には以下の変更を加えました。
・各投稿に設置されている4つのいいねボタンを横一列の配置にする
・いいねボタンのclassを、まだクリックされていないときはbtn-outline-successに、すでにクリック済のときはbtn-successに設定する(これにより、ボタンが押されているかいないかを色の有無で判断できるようになった)
・進捗ページ行きのリンクを、ボタンに変える
