### PR TITLE
投稿一覧ページのレイアウトを改善

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -61,10 +61,27 @@ li {
   list-style: none;
 }
 
+.user_icon {
+  width: 50px;
+}
+
 
 .wrapper {
   display: flex;
   flex-direction: column;
+
+  ul {
+    border: solid 1px #f07f5d;
+    background: #fffaf1;
+    padding: 0.5em 1em 0.5em 2.3em;
+    position: relative;
+
+    li {
+      line-height: 1.5;
+      padding: 0.5em 0;
+      list-style-type: none!important;
+    }
+  }
 }
 
 .field {
@@ -170,6 +187,7 @@ aside {
 .posts {
   list-style: none;
   padding: 0;
+
   li {
     padding: 10px 0;
     border-top: 1px solid #e8e8e8;
@@ -178,10 +196,6 @@ aside {
   .user {
     margin-top: 5em;
     padding-top: 0;
-  }
-
-  .user_icon {
-    width: 50px;
   }
 
   // .content {
@@ -194,28 +208,54 @@ aside {
     margin-left: 60px;
   }
 
-
-  .wakaru_button {
-    padding-left: 80px;
-    display: inline-block;
-  }
-
-  .like_button {
-    display: inline-block;
-  }
-
-  .teinei_button {
-    display: inline-block;
-  }
-
-  .ouen_button {
-    display: inline-block;
-  }
-
   #progress_button {
     width: 40%;
   }
 }
+
+
+
+
+.buttons {
+  margin: 10px 0;
+  text-align: center;
+
+    .wakaru_button {
+      display: inline-block;
+    }
+
+    .like_button {
+      display: inline-block;
+    }
+
+    .teinei_button {
+      display: inline-block;
+    }
+
+    .ouen_button {
+      display: inline-block;
+    }
+
+    .sounanda_button {
+      display: inline-block;
+    }
+
+    .erai_button {
+      display: inline-block;
+    }
+
+    .teinei2_button {
+      display: inline-block;
+    }
+
+    .ouen2_button {
+      display: inline-block;
+    }
+}
+
+
+
+
 
 aside {
   textarea {

--- a/app/views/erais/_erai.html.erb
+++ b/app/views/erais/_erai.html.erb
@@ -1,22 +1,18 @@
 <% erai = @progress.erais.find_by(user_id: current_user.id) %>
-<div id="erai_button_<%= @progress.id %>">
-  <% if @progress.has_erai?(current_user) %>
-    <div class="erai">
-      <div class="row">
-        <div class="col-md-4 offset-md-4">
-          <%= button_to 'よかった済', post_progress_erai_path(progress_id: @progress.id, id: erai.id), class: 'btn btn-outline-info', id: 'unerai-button', method: :delete, remote: true %>
-          <%= @progress.erais.count %>
-        </div>
+<div class="erai_button">
+  <div id="erai_button_<%= @progress.id %>">
+    <% if @progress.has_erai?(current_user) %>
+      <div class="erai">
+        <%= button_to "よかった   #{@progress.erais.count}", post_progress_erai_path(progress_id: @progress.id, id: erai.id), class: 'btn btn-success', id: 'unerai-button', method: :delete, remote: true %>
       </div>
-    </div>
-  <% else %>
-    <div class="unerai">
-      <div class="row">
-        <div class="col-md-4 offset-md-4">
-          <%= button_to 'よかった', post_progress_erais_path(progress_id: @progress.id), class: 'btn btn-outline-info', id: 'erai-button', method: :post, remote: true %>
-          <%= @progress.erais.count %>
-        </div>
+    <% else %>
+      <div class="unerai">
+        <% if @progress.erais.count == 0 %>
+          <%= button_to "よかった", post_progress_erais_path(progress_id: @progress.id), class: 'btn btn-outline-success', id: 'erai-button', method: :post, remote: true %>
+        <% else %>
+          <%= button_to "よかった   #{@progress.erais.count}", post_progress_erais_path(progress_id: @progress.id), class: 'btn btn-outline-success', id: 'erai-button', method: :post, remote: true %>
+        <% end %>
       </div>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/likes/_like.html.erb
+++ b/app/views/likes/_like.html.erb
@@ -3,13 +3,15 @@
   <div id="like_button_<%= post.id %>">
     <% if post.has_like?(current_user) %>
       <div class="like">
-        <%= button_to 'そうなんだ', post_like_path(id: like.id, post_id: post.id), class: 'btn btn-success', id: 'unlike-button', method: :delete, remote: true %>
-        <%= post.likes.count %>
+        <%= button_to "そうなんだ   #{post.likes.count}", post_like_path(id: like.id, post_id: post.id), class: 'btn btn-success', id: 'unlike-button', method: :delete, remote: true %>
       </div>
     <% else %>
       <div class="unlike">
-        <%= button_to 'そうなんだ', post_likes_path(post_id: post.id), class: 'btn btn-outline-success', id: 'like-button', method: :post, remote: true %>
-        <%= post.likes.count %>
+        <% if post.likes.count == 0 %>
+          <%= button_to "そうなんだ", post_likes_path(post_id: post.id), class: 'btn btn-outline-success', id: 'like-button', method: :post, remote: true %>
+        <% else %>
+          <%= button_to "そうなんだ   #{post.likes.count}", post_likes_path(post_id: post.id), class: 'btn btn-outline-success', id: 'like-button', method: :post, remote: true %>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/ouen2s/_ouen2.html.erb
+++ b/app/views/ouen2s/_ouen2.html.erb
@@ -1,22 +1,18 @@
 <% ouen2 = @progress.ouen2s.find_by(user_id: current_user.id) %>
-<div id="ouen2_button_<%= @progress.id %>">
-  <% if @progress.has_ouen2?(current_user) %>
-    <div class="ouen2">
-      <div class="row">
-        <div class="col-md-4 offset-md-4">
-          <%= button_to 'おうえん済', post_progress_ouen2_path(progress_id: @progress.id, id: ouen2.id), class: 'btn btn-outline-info', id: 'unouen2-button', method: :delete, remote: true %>
-          <%= @progress.ouen2s.count %>
-        </div>
+<div class="ouen2_button">
+  <div id="ouen2_button_<%= @progress.id %>">
+    <% if @progress.has_ouen2?(current_user) %>
+      <div class="ouen2">
+        <%= button_to "おうえん   #{@progress.ouen2s.count}", post_progress_ouen2_path(progress_id: @progress.id, id: ouen2.id), class: 'btn btn-success', id: 'unouen2-button', method: :delete, remote: true %>
       </div>
-    </div>
-  <% else %>
-    <div class="unouen2">
-      <div class="row">
-        <div class="col-md-4 offset-md-4">
-          <%= button_to 'おうえん', post_progress_ouen2s_path(progress_id: @progress.id), class: 'btn btn-outline-info', id: 'ouen2-button', method: :post, remote: true %>
-          <%= @progress.ouen2s.count %>
-        </div>
+    <% else %>
+      <div class="unouen2">
+        <% if @progress.ouen2s.count == 0 %>
+          <%= button_to "おうえん", post_progress_ouen2s_path(progress_id: @progress.id), class: 'btn btn-outline-success', id: 'ouen2-button', method: :post, remote: true %>
+        <% else %>
+          <%= button_to "おうえん   #{@progress.ouen2s.count}", post_progress_ouen2s_path(progress_id: @progress.id), class: 'btn btn-outline-success', id: 'ouen2-button', method: :post, remote: true %>
+        <% end %>
       </div>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/ouens/_ouen.html.erb
+++ b/app/views/ouens/_ouen.html.erb
@@ -3,13 +3,16 @@
   <div id="ouen_button_<%= post.id %>">
     <% if post.has_ouen?(current_user) %>
       <div class="ouen">
-        <%= button_to 'おうえん', post_ouen_path(id: ouen.id, post_id: post.id), class: 'btn btn-success', id: 'unouen-button', method: :delete, remote: true %>
-        <%= post.ouens.count %>
+        <%= button_to "おうえん   #{post.ouens.count}", post_ouen_path(id: ouen.id, post_id: post.id), class: 'btn btn-success', id: 'unouen-button', method: :delete, remote: true %>
+        <%=  %>
       </div>
     <% else %>
       <div class="unouen">
-        <%= button_to 'おうえん', post_ouens_path(post_id: post.id), class: 'btn btn-outline-success', id: 'ouen-button', method: :post, remote: true %>
-        <%= post.ouens.count %>
+        <% if post.ouens.count == 0 %>
+          <%= button_to "おうえん", post_ouens_path(post_id: post.id), class: 'btn btn-outline-success', id: 'ouen-button', method: :post, remote: true %>
+        <% else %>
+          <%= button_to "おうえん   #{post.ouens.count}", post_ouens_path(post_id: post.id), class: 'btn btn-outline-success', id: 'ouen-button', method: :post, remote: true %>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/progresses/show.html.erb
+++ b/app/views/progresses/show.html.erb
@@ -9,73 +9,55 @@
   });
 </script>
 
+<div class="row">
+<div class="col-md-8 offset-md-2">
 <div class="wrapper">
   <div class="accordion_wrapper">
     <div class="accordion_title">困りごとの内容</div>
-    <div class="accordion_content">
-      <table class="table table-hover">
-        <tbody>
-          <tr>
-            <th>どんなことに困っていますか？</th>
-            <td><%= simple_format(h(@post.content), {}, sanitize: false, wrapper_tag: 'div') %></td>
-          </tr>
-          <% if @post.optional_content.present? %>
-          <tr>
-            <th>困りごとのきっかけは何でしたか？</th>
-            <td><%= simple_format(h(@post.optional_content), {}, sanitize: false, wrapper_tag: 'div') %></td>
-          </tr>
-          <% end %>
-          <% if @post.optional_content_2.present? %>
-          <tr>
-            <th>困りごとはどのような状況で発生しますか？</th>
-            <td><%= simple_format(h(@post.optional_content_2), {}, sanitize: false, wrapper_tag: 'div') %></td>
-          </tr>
-          <% end %>
-          <% if @post.optional_content_3.present? %>
-          <tr>
-            <th>どうなればうれしいですか？</th>
-            <td><%= simple_format(h(@post.optional_content_3), {}, sanitize: false, wrapper_tag: 'div') %></td>
-          </tr>
-          <% end %>
-          <% if @post.optional_content_4.present? %>
-          <tr>
-            <th>よくしていくために、これからどうしますか？</th>
-            <td><%= simple_format(h(@post.optional_content_4), {}, sanitize: false, wrapper_tag: 'div') %></td>
-          </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
+    <ul class="accordion_content">
+      <li><i class="fa fa-paw fa-fw"></i>どんなことに困っていますか？</p>
+      <p><%= simple_format(h(@post.content), {}, sanitize: false, wrapper_tag: 'div') %></p>
+      <% if @post.optional_content.present? %>
+        <li><i class="fa fa-paw fa-fw"></i>困りごとのきっかけは何でしたか？</p>
+        <p><%= simple_format(h(@post.optional_content), {}, sanitize: false, wrapper_tag: 'div') %></p>
+      <% end %>
+      <% if @post.optional_content_2.present? %>
+        <li><i class="fa fa-paw fa-fw"></i>困りごとはどのような状況で発生しますか？</p>
+        <p><%= simple_format(h(@post.optional_content_2), {}, sanitize: false, wrapper_tag: 'div') %></p>
+      <% end %>
+      <% if @post.optional_content_3.present? %>
+        <li><i class="fa fa-paw fa-fw"></i>どうなればうれしいですか？</p>
+        <p><%= simple_format(h(@post.optional_content_3), {}, sanitize: false, wrapper_tag: 'div') %></p>
+      <% end %>
+      <% if @post.optional_content_4.present? %>
+        <li><i class="fa fa-paw fa-fw"></i>よくしていくために、これからどうしますか？</p>
+        <p><%= simple_format(h(@post.optional_content_4), {}, sanitize: false, wrapper_tag: 'div') %></p>
+      <% end %>
+    </ul>
   </div>
 
-  <table class="table table-hover">
-    <tbody>
-      <tr>
-        <th>その後はいかがですか？</th>
-        <td><%= simple_format(h(@progress.content), {}, sanitize: false, wrapper_tag: 'div') %></td>
-      </tr>
-      <% if @progress.optional_content.present? %>
-      <tr>
-        <th>前回から今回の投稿までの間に、してよかったことはありますか？</th>
-        <td><%= simple_format(h(@progress.optional_content), {}, sanitize: false, wrapper_tag: 'div') %></td>
-      </tr>
-      <% end %>
-      <% if @progress.optional_content_2.present? %>
-      <tr>
-        <th>前回から心境の変化はありますか？</th>
-        <td><%= simple_format(h(@progress.optional_content_2), {}, sanitize: false, wrapper_tag: 'div') %></td>
-      </tr>
-      <% end %>
-    </tbody>
-  </table>
+  <p><i class="fa fa-paw fa-fw"></i>その後はいかがですか？</p>
+  <p><%= simple_format(h(@progress.content), {}, sanitize: false, wrapper_tag: 'div') %></p>
+  <% if @progress.optional_content.present? %>
+    <p><i class="fa fa-paw fa-fw"></i>前回から今回の投稿までの間に、してよかったことはありますか？</p>
+    <p><%= simple_format(h(@progress.optional_content), {}, sanitize: false, wrapper_tag: 'div') %></p>
+  <% end %>
+  <% if @progress.optional_content_2.present? %>
+    <p><i class="fa fa-paw fa-fw"></i>前回から心境の変化はありますか？</p>
+    <p><%= simple_format(h(@progress.optional_content_2), {}, sanitize: false, wrapper_tag: 'div') %></p>
+  <% end %>
 </div>
 
-<%= render 'sounandas/sounanda' %>
-<%= render 'erais/erai' %>
-<%= render 'teinei2s/teinei2' %>
-<%= render 'ouen2s/ouen2' %>
+<div class="buttons">
+  <%= render 'sounandas/sounanda' %>
+  <%= render 'erais/erai' %>
+  <%= render 'teinei2s/teinei2' %>
+  <%= render 'ouen2s/ouen2' %>
+</div>
 
 <% if @user == current_user %>
   <%= link_to '編集', edit_post_progress_path, class: 'btn btn-primary mr-3' %>
   <%= link_to '削除', post_progress_path, method: :delete, data: {confirm: 'この進捗を削除します。よろしいですか？'}, class: 'btn btn-danger' %>
 <% end %>
+</div>
+</div>

--- a/app/views/sounandas/_sounanda.html.erb
+++ b/app/views/sounandas/_sounanda.html.erb
@@ -1,22 +1,18 @@
 <% sounanda = @progress.sounandas.find_by(user_id: current_user.id) %>
-<div id="sounanda_button_<%= @progress.id %>">
-  <% if @progress.has_sounanda?(current_user) %>
-    <div class="sounanda">
-      <div class="row">
-        <div class="col-md-4 offset-md-4">
-          <%= button_to 'そうなんだ済', post_progress_sounanda_path(progress_id: @progress.id, id: sounanda.id), class: 'btn btn-outline-info', id: 'unsounanda-button', method: :delete, remote: true %>
-          <%= @progress.sounandas.count %>
-        </div>
+<div class="sounanda_button">
+  <div id="sounanda_button_<%= @progress.id %>">
+    <% if @progress.has_sounanda?(current_user) %>
+      <div class="sounanda">
+        <%= button_to "そうなんだ   #{@progress.sounandas.count}", post_progress_sounanda_path(progress_id: @progress.id, id: sounanda.id), class: 'btn btn-success', id: 'unsounanda-button', method: :delete, remote: true %>
       </div>
-    </div>
-  <% else %>
-    <div class="unsounanda">
-      <div class="row">
-        <div class="col-md-4 offset-md-4">
-          <%= button_to 'そうなんだ', post_progress_sounandas_path(progress_id: @progress.id), class: 'btn btn-outline-info', id: 'sounanda-button', method: :post, remote: true %>
-          <%= @progress.sounandas.count %>
-        </div>
+    <% else %>
+      <div class="unsounanda">
+        <% if @progress.sounandas.count == 0 %>
+          <%= button_to "そうなんだ", post_progress_sounandas_path(progress_id: @progress.id), class: 'btn btn-outline-success', id: 'sounanda-button', method: :post, remote: true %>
+        <% else %>
+          <%= button_to "そうなんだ   #{@progress.sounandas.count}", post_progress_sounandas_path(progress_id: @progress.id), class: 'btn btn-outline-success', id: 'sounanda-button', method: :post, remote: true %>
+        <% end %>
       </div>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/teinei2s/_teinei2.html.erb
+++ b/app/views/teinei2s/_teinei2.html.erb
@@ -1,22 +1,18 @@
 <% teinei2 = @progress.teinei2s.find_by(user_id: current_user.id) %>
-<div id="teinei2_button_<%= @progress.id %>">
-  <% if @progress.has_teinei2?(current_user) %>
-    <div class="teinei2">
-      <div class="row">
-        <div class="col-md-4 offset-md-4">
-          <%= button_to 'ていねい済', post_progress_teinei2_path(progress_id: @progress.id, id: teinei2.id), class: 'btn btn-outline-info', id: 'unteinei2-button', method: :delete, remote: true %>
-          <%= @progress.teinei2s.count %>
-        </div>
+<div class="teinei2_button">
+  <div id="teinei2_button_<%= @progress.id %>">
+    <% if @progress.has_teinei2?(current_user) %>
+      <div class="teinei2">
+        <%= button_to "ていねい   #{@progress.teinei2s.count}", post_progress_teinei2_path(progress_id: @progress.id, id: teinei2.id), class: 'btn btn-success', id: 'unteinei2-button', method: :delete, remote: true %>
       </div>
-    </div>
-  <% else %>
-    <div class="unteinei2">
-      <div class="row">
-        <div class="col-md-4 offset-md-4">
-          <%= button_to 'ていねい', post_progress_teinei2s_path(progress_id: @progress.id), class: 'btn btn-outline-info', id: 'teinei2-button', method: :post, remote: true %>
-          <%= @progress.teinei2s.count %>
-        </div>
+    <% else %>
+      <div class="unteinei2">
+        <% if @progress.teinei2s.count == 0 %>
+          <%= button_to "ていねい", post_progress_teinei2s_path(progress_id: @progress.id), class: 'btn btn-outline-success', id: 'teinei2-button', method: :post, remote: true %>
+        <% else %>
+          <%= button_to "ていねい   #{@progress.teinei2s.count}", post_progress_teinei2s_path(progress_id: @progress.id), class: 'btn btn-outline-success', id: 'teinei2-button', method: :post, remote: true %>
+        <% end %>
       </div>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/teineis/_teinei.html.erb
+++ b/app/views/teineis/_teinei.html.erb
@@ -3,13 +3,15 @@
   <div id="teinei_button_<%= post.id %>">
     <% if post.has_teinei?(current_user) %>
       <div class="teinei">
-        <%= button_to 'ていねい', post_teinei_path(id: teinei.id, post_id: post.id), class: 'btn btn-success', id: 'unteinei-button', method: :delete, remote: true %>
-        <%= post.teineis.count %>
+        <%= button_to "ていねい   #{post.teineis.count}", post_teinei_path(id: teinei.id, post_id: post.id), class: 'btn btn-success', id: 'unteinei-button', method: :delete, remote: true %>
       </div>
     <% else %>
       <div class="unteinei">
-        <%= button_to 'ていねい', post_teineis_path(post_id: post.id), class: 'btn btn-outline-success', id: 'teinei-button', method: :post, remote: true %>
-        <%= post.teineis.count %>
+        <% if post.teineis.count == 0 %>
+          <%= button_to "ていねい", post_teineis_path(post_id: post.id), class: 'btn btn-outline-success', id: 'teinei-button', method: :post, remote: true %>
+        <% else %>
+          <%= button_to "ていねい   #{post.teineis.count}", post_teineis_path(post_id: post.id), class: 'btn btn-outline-success', id: 'teinei-button', method: :post, remote: true %>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,7 @@
         <%= image_tag @user.image, class: 'user_icon' %>
         <%= @user.name %>
       </h1>
-      <span><%= pluralize(@posts.count, '回投稿しています') %></span>
+      <span><%= pluralize(@posts.count, '個投稿しています') %></span>
     </section>
   </aside>
 </div>

--- a/app/views/wakarus/_wakaru.html.erb
+++ b/app/views/wakarus/_wakaru.html.erb
@@ -3,13 +3,15 @@
   <div id="wakaru_button_<%= post.id %>">
     <% if post.has_wakaru?(current_user) %>
       <div class="wakaru">
-        <%= button_to 'わかる', post_wakaru_path(id: wakaru.id, post_id: post.id), class: 'btn btn-success', id: 'unwakaru-button', method: :delete, remote: true %>
-        <%= post.wakarus.count %>
+        <%= button_to "わかる   #{post.wakarus.count}", post_wakaru_path(id: wakaru.id, post_id: post.id), class: 'btn btn-success', id: 'unwakaru-button', method: :delete, remote: true %>
       </div>
     <% else %>
       <div class="unwakaru">
-        <%= button_to 'わかる', post_wakarus_path(post_id: post.id), class: 'btn btn-outline-success', id: 'wakaru-button', method: :post, remote: true %>
-        <%= post.wakarus.count %>
+        <% if post.wakarus.count == 0 %>
+          <%= button_to 'わかる', post_wakarus_path(post_id: post.id), class: 'btn btn-outline-success', id: 'wakaru-button', method: :post, remote: true %>
+        <% else %>
+          <%= button_to "わかる   #{post.wakarus.count}", post_wakarus_path(post_id: post.id), class: 'btn btn-outline-success', id: 'wakaru-button', method: :post, remote: true %>
+        <% end %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
投稿一覧ページ, 投稿詳細ページ, 進捗詳細ページのレイアウトを改善しました。
具体的には、投稿一覧ページのリアクションボタンを一列に並べたり、進捗詳細ページの箇条書きのドットをFontAwesomeの肉球アイコンに変えたりしました。