### PR TITLE
投稿一覧ページのレイアウト改善

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -139,10 +139,9 @@ input, textarea, select, .uneditable-input {
 // }
 
 /* ページネーション */
-nav {
+.paginate {
+  width: 100%;
   .pagination {
-    margin: 0 auto;
-    width: 200%;
     li{
       a {
       border: none;
@@ -213,6 +212,24 @@ aside {
       display: inline-block;
       position: relative;
       right: 30px;
+
+      .fa-angle-down {
+        position: relative;
+        left: 230px;
+        top: 5px;
+      }
+
+      .my-size {
+        font-size: 1.7em;
+      }
+
+      .dropdown-menu {
+        width: 20%;
+      }
+
+      .fa-angle-down:hover {
+        cursor: pointer;
+      }
     }
   }
 
@@ -236,16 +253,18 @@ aside {
     margin-left: 30px;
   }
 
-  .progress_form_button {
-    width: 70%;
-    margin-top: 10px;
-    margin-left: 20px;
-  }
-
-  .progress_index_button {
-    width: 70%;
-    display: inline-block;
+  .progress_buttons {
     text-align: center;
+
+    .progress_form_button {
+      width: 70%;
+      display: inline-block;
+    }
+
+    .progress_index_button {
+      width: 70%;
+      display: inline-block;
+    }
   }
 }
 

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -7,6 +7,15 @@
         <li class="timestamp">
           <%= time_ago_in_words(post.created_at) %>前
         </li>
+        <% if post.user == current_user %>
+        <li class="dropdown">
+          <i class="fa fa-angle-down my-size" id="dropdownMenu1" data-toggle="dropdown"></i>
+          <div class="dropdown-menu" aria-labelledby="dropdownMenu1">
+            <%= link_to '編集', edit_post_path(id: post.id), class: 'dropdown-item' %>
+            <%= link_to '削除', post_path(id: post.id), method: :delete, class: 'dropdown-item' %>
+          </div>
+        </li>
+        <% end %>
       </ul>
       <div class="row">
         <div class="col-md-11 offset-md-0">
@@ -38,12 +47,14 @@
         <%= render 'teineis/teinei', post: post %>
         <%= render 'ouens/ouen', post: post %>
       </div>
-      <% if post.progresses.present? %>
-        <%= button_to 'その後の進捗を見る', post_progresses_path(post_id: post.id), method: :get, class: 'btn btn-outline-primary progress_index_button' %>
-      <% end %>
+      <div class="progress_buttons">
       <% if post.user == current_user %>
         <%= button_to 'その後の進捗を記録する', new_post_progress_path(post_id: post.id), method: :get, class: 'btn btn-outline-primary progress_form_button' %>
       <% end %>
+      <% if post.progresses.present? %>
+        <%= button_to 'その後の進捗を見る', post_progresses_path(post_id: post.id), method: :get, class: 'btn btn-outline-primary progress_index_button' %>
+      <% end %>
+      </div>
     </li>
   <% end %>
 </ul>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'search_form' %>
 <div class="row">
   <div class="col-md-6 offset-md-3">
-    <% if @posts.any? %>
+    <% if @posts.exists? %>
       <%= render 'post' %>
     <% end %>
   </div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end


### PR DESCRIPTION
投稿一覧ページのレイアウト改善をしました。
具体的には、まず投稿一覧ページから投稿詳細ページへの導線を消去しました。そして投稿一覧ページの各投稿の右上に、押下すると編集と削除の選択肢がドロップダウンされる矢印アイコンを追加しました。