### PR TITLE
モーダルウィンドウの作成

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,10 @@
 <header class="navbar fixed-top navbar-expand-lg navbar-light bg-light">
   <div class="container">
-    <div class="navbar-brand"><%= link_to '困りごとひろば', root_path %><i class="fa fa-paw fa-fw"></i></div>
+    <div class="navbar-brand">
+      <%= link_to root_path do %>
+      困りごとひろば<i class="fa fa-paw fa-fw"></i>
+      <% end %>
+    </div>
     <% if logged_in? %>
       <li><%= link_to '困りごとを投稿', new_post_path %></li>
       <li><%= link_to 'みんなの困りごと', posts_path %></li>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -37,11 +37,3 @@
     <%= f.submit yield(:button_text), class: 'btn btn-primary js-modal-open submit_ajax' %>
   </div>
 <% end %>
-
-<div class="modal js-modal">
-  <div class="modal__bg js-modal-close"></div>
-  <div class="modal__content">
-    <p>ここにモーダルウィンドウで表示したいコンテンツを入れます。モーダルウィンドウを閉じる場合は下の「閉じる」をクリックするか、背景の黒い部分をクリックしても閉じることができます。</p>
-    <a class="js-modal-close" href="">閉じる</a>
-  </div>
-</div>

--- a/app/views/posts/_modal.js
+++ b/app/views/posts/_modal.js
@@ -1,0 +1,15 @@
+$(function(){
+
+  $('.js-modal-open').on('click',function(){
+    $('.js-modal').fadeIn();
+    return false;
+  });
+
+  $('.js-modal-close').on('click',function(){
+    $('.js-modal').fadeOut();
+    return false;
+  });
+
+  $('js-modal-open').trigger('click');
+
+});

--- a/app/views/posts/create.js.erb
+++ b/app/views/posts/create.js.erb
@@ -1,8 +1,0 @@
-$.ajax({
-  url: '/posts'
-  type: 'POST'
-  dataType: 'json'
-})
-.done(function() {
-  $(".js-modal").modal(show);
-});

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,8 +1,41 @@
 <%= render 'search_form' %>
+
+<div class="js-modal-open">
+  <div class="modal js-modal">
+    <div class="modal__bg js-modal-close"></div>
+    <div class="modal__content">
+      <p>SNSで共有しませんか？</p>
+      <%= link_to 'Twitter', "https://twitter.com/share?url=#{request.url}", title: 'Twitter', target: '_blank' %>
+      <a class="js-modal-close" href="">閉じる</a>
+    </div>
+  </div>
+</div>
+
+
+<script>
+$(function(){
+  $('.js-modal-open').on('click',function(){
+    $('.js-modal').fadeIn();
+    return false;
+  });
+  $('.js-modal-close').on('click',function(){
+    $('.js-modal').fadeOut();
+    return false;
+  });
+});
+</script>
+
 <div class="row">
   <div class="col-md-6 offset-md-3">
     <% if @posts.exists? %>
       <%= render 'post' %>
+    <% end %>
+    <% if flash[:success] == ('困りごとを投稿しました！' || '困りごとを投稿しました。追加項目も書いてすごい！' || '無理のない範囲で、今できることを実行してみてくださいね。おうえんしています' || '最後まで書いてすごい！ あなたが今日心おだやかでありますように・・・') %>
+      <script>
+      $(function(){
+        $('.js-modal-open').trigger('click');
+        });
+      </script>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
困りごと投稿後に、モーダルウィンドウが表示されるよう設定しました。
具体的には、投稿一覧ページにredirectした後、flash[:success]が特定の値であればモーダルウィンドウが発火するようにコーディングしました。
今後は以下2点の改善を行う予定です。
・index.html.erbにjsを直書きしているので、外部に切り分ける
・モーダルウィンドウのSNSシェアボタンを押しても外部リンクに移動しないので、その問題を解決する