### PR TITLE
ログイン後の移遷を投稿一覧ページに変更

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
     if user && user.authenticate(params[:session][:password])
       log_in user
       flash[:success] = 'ログインしました'
-      redirect_back_or user
+      redirect_back_or posts_url
     else
       flash.now[:danger] = 'メールアドレス、またはパスワードが正しくありません'
       render 'new'


### PR DESCRIPTION
ログイン後、ユーザー詳細ページに移遷していた仕様を、投稿一覧ページへの移遷に変更しました。