### PR TITLE
ギフト機能の改善

### DIFF
--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the card controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -16,6 +16,9 @@ $gray-medium-light: #eaeaea;
   box-sizing:         border-box;
 }
 
+.w-30px {
+  width: 70px !important;
+}
 
 /// アプリ全般 ///
 
@@ -630,13 +633,17 @@ span.image {
     text-align: center;
 
     .progress_form_button {
-      width: 70%;
       display: inline-block;
+      width: 35%;
+      margin:0 auto;
+      text-align: center;
     }
 
     .progress_index_button {
-      width: 70%;
       display: inline-block;
+      width: 35%;
+      margin:0 auto;
+      text-align: center;
     }
   }
 }
@@ -778,6 +785,11 @@ span.image {
 
     .sounanda_button {
       display: inline-block;
+    }
+
+    .gift_button {
+      display: inline-block;
+      vertical-align: top;
     }
 
     .erai_button {

--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -1,0 +1,7 @@
+class CardController < ApplicationController
+  def new
+  end
+
+  def show
+  end
+end

--- a/app/controllers/gifts_controller.rb
+++ b/app/controllers/gifts_controller.rb
@@ -14,6 +14,8 @@ class GiftsController < ApplicationController
       :card => params['payjp-token'],
       :currency => 'jpy'
     )
+    flash[:info] = '送金が完了しました'
+    redirect_to posts_url
   end
 
   def delete

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -28,13 +28,17 @@ class PostsController < ApplicationController
     @post = current_user.posts.new(post_params)
     if @post.save
       if @post.optional_content_4.present?
-        flash[:success] = '最後まで書いてすごい！ あなたが今日心おだやかでありますように・・・'
+        # flash[:post] = '最後まで書いてすごい！ あなたが今日心おだやかでありますように・・・'
+        flash[:post] = '4'
       elsif @post.optional_content_3.present?
-        flash[:success] = '無理のない範囲で、今できることを実行してみてくださいね。おうえんしています'
+        # flash[:post] = '無理のない範囲で、今できることを実行してみてくださいね。おうえんしています'
+        flash[:post] = '3'
       elsif @post.optional_content.present? || @post.optional_content_2.present?
-        flash[:success] = '困りごとを投稿しました。追加項目も書いてすごい！'
+        # flash[:post] = '困りごとを投稿しました。追加項目も書いてすごい！'
+        flash[:post] = '2'
       else
-        flash[:success] = '困りごとを投稿しました！'
+        # flash[:post] = '困りごとを投稿しました！'
+        flash[:post] = '1'
       end
       redirect_to posts_url
     else
@@ -49,7 +53,7 @@ class PostsController < ApplicationController
   def update
     @post = Post.find_by(id: params[:id])
     if @post.update(post_params)
-      flash[:success] = '投稿を更新しました'
+      flash[:info] = '投稿を更新しました'
       redirect_to posts_url
     else
       render 'edit'
@@ -58,7 +62,7 @@ class PostsController < ApplicationController
 
   def destroy
     Post.find_by(id: params[:id]).destroy
-    flash[:success] = '投稿を削除しました'
+    flash[:info] = '投稿を削除しました'
     redirect_to posts_url
   end
 

--- a/app/controllers/progresses_controller.rb
+++ b/app/controllers/progresses_controller.rb
@@ -12,11 +12,11 @@ class ProgressesController < ApplicationController
     @progress = @post.progresses.new(progress_params)
     if @progress.save
       if @progress.optional_content_3.present?
-        flash[:success] = '最後まで書いてすごい！ あなたが今日心おだやかでありますように・・・'
+        flash[:info] = '最後まで書いてすごい！ あなたが今日心おだやかでありますように・・・'
       elsif @progress.optional_content_2.present?
-        flash[:success] = '無理のない範囲で、今できることを実行してみてくださいね。おうえんしています'
+        flash[:info] = '無理のない範囲で、今できることを実行してみてくださいね。おうえんしています'
       else
-        flash[:success] = '進捗を投稿しました！'
+        flash[:info] = '進捗を投稿しました！'
       end
       redirect_to posts_url
     else
@@ -39,7 +39,7 @@ class ProgressesController < ApplicationController
     @post = Post.find_by(id: params[:post_id])
     @progress = Progress.find_by(id: params[:id])
     if @progress.update(progress_params)
-      flash[:success] = '進捗を更新しました'
+      flash[:info] = '進捗を更新しました'
       redirect_to post_progresses_url
     else
       render 'edit'
@@ -53,7 +53,7 @@ class ProgressesController < ApplicationController
 
   def destroy
     Progress.find_by(id: params[:id]).destroy
-    flash[:success] = '進捗を削除しました'
+    flash[:info] = '進捗を削除しました'
     redirect_to posts_url
   end
 

--- a/app/helpers/card_helper.rb
+++ b/app/helpers/card_helper.rb
@@ -1,0 +1,2 @@
+module CardHelper
+end

--- a/app/views/card/new.html.erb
+++ b/app/views/card/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Card#new</h1>
+<p>Find me in app/views/card/new.html.erb</p>

--- a/app/views/card/show.html.erb
+++ b/app/views/card/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Card#show</h1>
+<p>Find me in app/views/card/show.html.erb</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,13 @@
   </head>
   <body>
     <%= render 'layouts/header' %>
+    <% flash.each do |name, msg| %>
+      <% if name != 'post' %>
+        <div class="alert alert-<%= name %>">
+          <%= msg.html_safe %>
+        </div>
+      <% end %>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -46,13 +46,24 @@
         <%= render 'wakarus/wakaru', post: post %>
         <%= render 'teineis/teinei', post: post %>
         <%= render 'ouens/ouen', post: post %>
+        <div class="gift_button">
+          <% if post.user != current_user %>
+            <%= button_to new_gift_path, method: :get, class: 'btn btn-outline-dark' do %>
+              <i class="fas fa-gift"></i>
+            <% end %>
+          <% end %>
+        </div>
       </div>
       <div class="progress_buttons">
         <% if post.user == current_user %>
-          <%= button_to 'その後の進捗を記録する', new_post_progress_path(post_id: post.id), method: :get, class: 'btn btn-outline-primary progress_form_button' %>
+          <div class="progress_form_button">
+            <%= button_to '進捗を記録する', new_post_progress_path(post_id: post.id), method: :get, class: 'btn btn-outline-dark' %>
+          </div>
         <% end %>
         <% if post.progresses.present? %>
-          <%= button_to 'その後の進捗を見る', post_progresses_path(post_id: post.id), method: :get, class: 'btn btn-outline-primary progress_index_button' %>
+          <div class="progress_index_button">
+            <%= button_to "進捗 #{post.progresses.count}件", post_progresses_path(post_id: post.id), method: :get, class: 'btn btn-outline-dark' %>
+          </div>
         <% end %>
       </div>
     </li>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,6 +5,15 @@
   <div class="modal js-modal">
     <div class="modal__bg js-modal-close"></div>
     <div class="modal__content">
+      <% if flash[:post] == '4' %>
+        <p>最後まで書いてすごい！ あなたが今日心おだやかでありますように・・・'</p>
+      <% elsif flash[:post] == '3' %>
+        <p>無理のない範囲で、今できることを実行してみてくださいね。おうえんしています</p>
+      <% elsif flash[:post] == '2' %>
+        <p>困りごとを投稿しました。追加項目も書いてすごい！</p>
+      <% elsif flash[:post] == '1' %>
+        <p>困りごとを投稿しました。</p>
+      <% end %>
       <p>今のあなたの気持ちをシェアしてみませんか？</p>
       <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
       <div class="fb-share-button" data-href="https://developers.facebook.com/docs/plugins/" data-layout="button" data-size="small"><a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdevelopers.facebook.com%2Fdocs%2Fplugins%2F&amp;src=sdkpreparse" class="fb-xfbml-parse-ignore">シェア</a></div>
@@ -34,13 +43,14 @@ $(function(){
     <% if @posts.exists? %>
       <%= render 'post' %>
     <% end %>
-    <% if flash[:success] == ('困りごとを投稿しました！' || '困りごとを投稿しました。追加項目も書いてすごい！' || '無理のない範囲で、今できることを実行してみてくださいね。おうえんしています' || '最後まで書いてすごい！ あなたが今日心おだやかでありますように・・・') %>
+    <% if flash[:post] == '1' || flash[:post] == '2' || flash[:post] == '3' || flash[:post] == '4' %>
       <script>
       $(function(){
         $('.js-modal-open').trigger('click');
         });
       </script>
     <% end %>
+    <%= debug flash[:post] %>
   </div>
 </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get 'card/new'
+  get 'card/show'
   root to: 'home#top'
   get '/signup', to: 'users#new'
   get '/login', to: 'sessions#new'

--- a/spec/helpers/card_helper_spec.rb
+++ b/spec/helpers/card_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the CardHelper. For example:
+#
+# describe CardHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe CardHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/card_request_spec.rb
+++ b/spec/requests/card_request_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe "Cards", type: :request do
+
+  describe "GET /new" do
+    it "returns http success" do
+      get "/card/new"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /show" do
+    it "returns http success" do
+      get "/card/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/card/new.html.erb_spec.rb
+++ b/spec/views/card/new.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "card/new.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/card/show.html.erb_spec.rb
+++ b/spec/views/card/show.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "card/show.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
・posts/indexページにgifts/newページへの導線を作る
・困りごとを投稿すると、入力した項目の数によって投稿後に表示されるモーダルウィンドウ内のメッセージが変わるよう設定
・gifts/newページでカード情報入力した後は、posts/indexページにリダイレクトするように設定